### PR TITLE
Fix two bugs relating to the data path

### DIFF
--- a/rabpro/utils.py
+++ b/rabpro/utils.py
@@ -31,7 +31,7 @@ def get_rabpropath():
     filepath = os.path.dirname(rp.__file__)
 
     # filepath = filepath.lower()
-    st_idx = filepath.index("rabpro")
+    st_idx = filepath.rindex("rabpro")
     # en_idx = st_idx + len("rabpro") 
     rabpropath = Path(filepath[:st_idx])
 
@@ -52,7 +52,7 @@ def get_datapaths(datapath=None):
         metadata_path = datapath / "data_metadata_darwin.csv"
     metadata = pd.read_csv(metadata_path)
     rel_paths = [rp.replace("\\", os.sep) for rp in metadata.rel_path.values]
-    dpaths = [str(basepath / Path(p)) for p in rel_paths]
+    dpaths = [str(datapath.parent.absolute() / Path(p)) for p in rel_paths]
     dnames = metadata.dataID.values
     datapaths = {dn: dp for dp, dn in zip(dpaths, dnames)}
     datapaths["metadata"] = metadata_path


### PR DESCRIPTION
- If the path to the rabpro module contains more than one instance of 'rabpro' in it, `filepath.index()` in `get_rabpropath()` removes everything after the first one, rather than everything after the last one. Uses `rindex` to fix.
- If `datapath` is not `None` in `get_datapaths()`, `basepath` is never set, so line 55 fails.