### PR TITLE
Improve MERIT download script

### DIFF
--- a/Data/scripts/get_merit_dem.py
+++ b/Data/scripts/get_merit_dem.py
@@ -2,8 +2,8 @@
 
 import argparse
 import os
-import shutil
 import re
+import shutil
 import tarfile
 import urllib.parse
 
@@ -44,6 +44,7 @@ def merit_hydro(target, username, password):
     response = requests.get(baseurl)
     soup = BeautifulSoup(response.text, "html.parser")
     urls = [x["href"][2:] for x in soup.findAll("a", text=re.compile(target), href=True)]
+    # The [2:] gets rid of the "./" in the URL
 
     for urlfile in urls:
         url = baseurl + urlfile
@@ -60,7 +61,6 @@ def merit_hydro(target, username, password):
 
 
 def download_file(url, filename, username, password):
-
     r = requests.get(url, auth=(username, password), stream=True)
     total_size = int(r.headers.get("content-length", 0))
 


### PR DESCRIPTION
This is purely for the MERIT files, since the Hydrobasin website is more annoying (they do have the data on dropbox, although I'm slightly hesitant to just take those URLs and hardcode them in since dropbox won't make any official firm commitments on permanent links). I think ultimately this could be bundled into the CLI and you could just run something like `rabpro download merit <tile> <user> <pwd>`

- Gets all MERIT data for tile
- Automatically puts files into the correct data directory and extracts from tar archive
- Takes tile, username, and password as arguments. Need to deal with MERIT DEM and Hydro having different passwords - maybe separate into two scripts?
- Fix tqdm progress bar