### PR TITLE
Add initial CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+title: >-
+  rabpro: global watershed boundaries, river
+  elevation profiles, and catchment statistics
+message: 'If you use this software, please cite it as below.'
+
+references:
+  - type: article
+    authors:
+      - given-names: Jon
+        family-names: Schwenk
+        affiliation: Los Alamos National Laboratory
+        orcid: 'https://orcid.org/0000-0001-5803-9686'
+      - given-names: Tal
+        family-names: Zussman
+        affiliation: Columbia University
+        orcid: 'https://orcid.org/0000-0003-3087-8511'
+      - given-names: Jemma
+        family-names: Stachelek
+        affiliation: '@lanl'
+        orcid: 'https://orcid.org/0000-0002-5924-2464'
+      - given-names: Joel C.
+        family-names: Rowland
+        orcid: 'https://orcid.org/0000-0001-6308-8976'
+    title: >-
+      rabpro: global watershed boundaries, river
+      elevation profiles, and catchment statistics
+    journal: Journal of Open Source Software
+    year: 2022
+    doi: 10.21105/joss.04237
+    url: https://doi.org/10.21105/joss.04237
+    
+license: BSD-3-Clause
+license-url: "https://github.com/VeinsOfTheEarth/rabpro/blob/main/LICENSE.txt"
+repository-code: "https://github.com/VeinsOfTheEarth/rabpro"
+type: software
+url: "https://github.com/VeinsOfTheEarth/rabpro"


### PR DESCRIPTION
This is a preliminary version for a CITATION file for rabpro - this adds a widget in the Github UI which displays the citation information. See [this](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) for more info.