### PR TITLE
Simplify _read_url()

### DIFF
--- a/rabpro/basin_stats.py
+++ b/rabpro/basin_stats.py
@@ -121,10 +121,9 @@ def _format_cols(df, prepend, col_drop_list, col_drop_defaults, col_protect_list
 def _read_url(url):
     df = pd.read_csv(url)
 
-    if "histogram" in [x for x in df.columns]:
+    if "histogram" in df.columns:
         histogram = df.histogram
-        df = df.drop(columns=["histogram", "mean"]).copy()
-        _str_to_dict(histogram[0])
+        df = df.drop(columns=["histogram", "mean"])
         histogram = [_str_to_dict(x) for x in histogram]
         histogram = pd.DataFrame(histogram)
         df = pd.concat([df, histogram], axis=1)


### PR DESCRIPTION
- `df.columns` is already iterable, don't need to turn into list
- `df.drop()` makes a copy, don't need to call `copy()`
- Remove unnecessary `_str_to_dict()` call

Actions run [here](https://github.com/tzussman/rabpro/actions/runs/2756514344)