### PR TITLE
Remove extraneous link underline between badges due to bad formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
   <a href=https://github.com/psf/black><img src=https://img.shields.io/badge/code%20style-black-000000.svg></a>
   <a href=https://anaconda.org/conda-forge/rabpro><img src=https://anaconda.org/conda-forge/rabpro/badges/version.svg></a>
   <a href=https://github.com/VeinsOfTheEarth/rabpro/actions/workflows/build.yaml><img src=https://github.com/VeinsOfTheEarth/rabpro/actions/workflows/build.yaml/badge.svg></a>
-  <a style="border-width:0" href="https://doi.org/10.21105/joss.04237">
-  <img src="https://joss.theoj.org/papers/10.21105/joss.04237/status.svg" alt="DOI badge" >
-</a>
-    <a href=https://doi.org/10.5281/zenodo.6600732><img src=https://zenodo.org/badge/DOI/10.5281/zenodo.6600732.svg></a>
+  <a style="border-width:0" href="https://doi.org/10.21105/joss.04237"><img src="https://joss.theoj.org/papers/10.21105/joss.04237/status.svg" alt="DOI badge" ></a>
+  <a href=https://doi.org/10.5281/zenodo.6600732><img src=https://zenodo.org/badge/DOI/10.5281/zenodo.6600732.svg></a>
 </p>
 
 Package to delineate watershed basins and compute attribute statistics using [Google Earth Engine](https://developers.google.com/earth-engine/).


### PR DESCRIPTION
Before:
<img width="369" height="57" alt="Screenshot 2025-08-20 at 5 27 10 PM" src="https://github.com/user-attachments/assets/dc5951ab-edec-43ba-9419-7a423fc4dbf3" />

After:
<img width="368" height="43" alt="Screenshot 2025-08-20 at 5 27 38 PM" src="https://github.com/user-attachments/assets/7672cb77-530c-4d03-bff4-d00e973760f3" />

Noticed while stealing the badge code for another repo 🫡 